### PR TITLE
Fix incorrect comparison when adding a server

### DIFF
--- a/classes.py
+++ b/classes.py
@@ -63,7 +63,7 @@ class Rack:
 		Rack.num_racks = Rack.num_racks - 1
 
 	def add_server(self, server):
-		if all(self.slots == EmptyServer(i, self.id) for i in range(server.slot, server.slot+server.size)):
+		if all(self.slots[i] == EmptyServer(i, self.id) for i in range(server.slot, server.slot+server.size)):
 			for i in range(server.size - 1):
 				self.slots[server.slot + 1 + i] = None
 			self.slots[server.slot] = server


### PR DESCRIPTION
The Rack.add_server method determines if the given server object can be
successfully added to the rack by ensuring the slots it would occupy
currently contain only EmptyServer objects with the correct properties.

The existing code incorrectly compared the *list* of objects
representing the slots in the rack to the desired EmptyServer objects.

This comparison was - as one would expect - always False, so no server
could ever be added to the rack.

Fixed by indexing the self.slots list, as was likely intended.